### PR TITLE
Fix crash on exit when Branch Output Status Dock is open

### DIFF
--- a/src/UI/output-status-dock.hpp
+++ b/src/UI/output-status-dock.hpp
@@ -246,6 +246,7 @@ public slots:
     void addRow(BranchOutputFilter *filter, size_t streamingIndex, RowOutputType outputType, size_t groupIndex = 0);
     void addFilter(BranchOutputFilter *filter);
     void removeFilter(BranchOutputFilter *filter);
+    void onObsShuttingDown();
     void setEabnleAll(bool enabled);
     void splitRecordingAll();
     void pauseRecordingAll();
@@ -262,7 +263,7 @@ class OutputTableRow : public QObject {
 
     friend class BranchOutputStatusDock;
 
-    BranchOutputFilter *filter;
+    QPointer<BranchOutputFilter> filter;
     FilterCell *filterCell;
     ParentCell *parentCell;
     StatusCell *status;

--- a/src/plugin-main.hpp
+++ b/src/plugin-main.hpp
@@ -26,11 +26,14 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <util/threading.h>
 
 #include <QObject>
+#include <QPointer>
 
 #include "UI/output-status-dock.hpp"
 #include "audio/audio-capture.hpp"
 
 #define MAX_SERVICES 8
+
+class QTimer;
 
 class BranchOutputFilter : public QObject {
     Q_OBJECT
@@ -73,7 +76,7 @@ class BranchOutputFilter : public QObject {
     bool initialized; // Activate after first "Apply" click
     uint32_t storedSettingsRev;
     uint32_t activeSettingsRev;
-    QTimer *intervalTimer;
+    QPointer<QTimer> intervalTimer;
     bool streamingStopping;
 
     // Filter source (Do not use OBSSourceAutoRelease)


### PR DESCRIPTION
-Fixes a crash on OBS exit when the Branch Output Status Dock is open.
-Root cause was shutdown‑order races/UAF between dock timer/UI updates and filter teardown.
-This PR hardens teardown by using QPointer for dock/timer/filter refs, adding null guards, and stopping/clearing the dock on frontend exit events.