### PR TITLE
Fix crash on exit when Branch Output Status Dock is open

### DIFF
--- a/src/UI/output-status-dock.cpp
+++ b/src/UI/output-status-dock.cpp
@@ -203,6 +203,8 @@ BranchOutputStatusDock::BranchOutputStatusDock(QWidget *parent)
 
 BranchOutputStatusDock::~BranchOutputStatusDock()
 {
+    timer.stop();
+
     saveSettings();
 
     // Unregister hotkeys
@@ -485,16 +487,43 @@ void BranchOutputStatusDock::resetStatsAll()
 
 void BranchOutputStatusDock::sort()
 {
-    outputTable->sortItems(sortingColumnIndex, sortingOrder);
-
-    for (int i = 0; i < outputTable->horizontalHeader()->count(); i++) {
-        if (i != sortingColumnIndex && i != resetColumnIndex) {
-            outputTable->horizontalHeaderItem(i)->setIcon(QIcon());
-        }
+    if (!outputTable) {
+        return;
     }
 
-    outputTable->horizontalHeaderItem(sortingColumnIndex)
-        ->setIcon((sortingOrder == Qt::AscendingOrder) ? ascendingIcon : descendingIcon);
+    QHeaderView *header = outputTable->horizontalHeader();
+    if (!header) {
+        return;
+    }
+
+    const int headerCount = header->count();
+    if (headerCount <= 0) {
+        return;
+    }
+
+    if (sortingColumnIndex < 0 || sortingColumnIndex >= headerCount) {
+        sortingColumnIndex = 0;
+    }
+
+    outputTable->sortItems(sortingColumnIndex, sortingOrder);
+
+    for (int i = 0; i < headerCount; i++) {
+        if (i == sortingColumnIndex || i == resetColumnIndex) {
+            continue;
+        }
+
+        QTableWidgetItem *item = outputTable->horizontalHeaderItem(i);
+        if (!item) {
+            continue;
+        }
+        item->setIcon(QIcon());
+    }
+
+    QTableWidgetItem *sortHeaderItem = outputTable->horizontalHeaderItem(sortingColumnIndex);
+    if (!sortHeaderItem) {
+        return;
+    }
+    sortHeaderItem->setIcon((sortingOrder == Qt::AscendingOrder) ? ascendingIcon : descendingIcon);
 }
 
 void BranchOutputStatusDock::onEanbleAllHotkeyPressed(void *data, obs_hotkey_id, obs_hotkey *, bool pressed)


### PR DESCRIPTION
The dock’s periodic update/sort could run while the table/header UI is being torn down. In that state horizontalHeaderItem(...) can be null (and/or the saved sortingColumnIndex can be out of range), leading to a null dereference inside sort().

Changes:
- Stop the dock update QTimer in ~BranchOutputStatusDock() to prevent late timer callbacks during teardown.
- Make BranchOutputStatusDock::sort() robust: guard against null table/header/header-items and clamp sortingColumnIndex to the current header count.

Hard to test since the crash is very rare, but should hopefully not happen again.