### PR TITLE
fix: Prevent SRT listener stop hang and audio encoder use-after-free (#147)

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -863,6 +863,16 @@ void BranchOutputFilter::releaseInfrastructureIfIdle()
         }
     }
 
+    // Stop the private video_t (joins its worker thread) before releasing the encoder, for
+    // the same reason as the audio_t above. obs_view_remove() only flags the mix for removal
+    // on the graphics thread, so it is not a synchronization point.
+    // FIXME: A GPU video encoder is driven from libobs' GPU encode thread via the mix's
+    // gpu_encoders array, which only obs_encoder_stop() detaches. Closing that path needs the
+    // output's start to be resolved before infrastructure is released.
+    if (videoOutput) {
+        video_output_stop(videoOutput);
+    }
+
     videoEncoder = nullptr;
 
     if (filterVideoCapture) {

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -846,12 +846,17 @@ void BranchOutputFilter::releaseInfrastructureIfIdle()
 
         for (size_t i = 0; i < MAX_AUDIO_MIXES; i++) {
             auto audioContext = &audios[i];
-            audioContext->encoder = nullptr;
 
+            // Close the audio_t (joins its worker thread) before releasing the
+            // encoder. The worker may still be inside receive_audio() for this
+            // encoder; the encoder (and its pause.mutex) must outlive that final
+            // iteration, otherwise the worker unlocks a destroyed mutex.
             if (audioContext->capture) {
                 delete audioContext->capture;
                 audioContext->capture = nullptr;
             }
+
+            audioContext->encoder = nullptr;
         }
     }
 

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -856,6 +856,9 @@ void BranchOutputFilter::releaseInfrastructureIfIdle()
                 audioContext->capture = nullptr;
             }
 
+            // audio is a borrowed pointer (capture-owned or obs_get_audio());
+            // clear it so it does not dangle until the next startOutput().
+            audioContext->audio = nullptr;
             audioContext->encoder = nullptr;
         }
     }

--- a/src/plugin-streaming.cpp
+++ b/src/plugin-streaming.cpp
@@ -58,6 +58,13 @@ obs_data_t *BranchOutputFilter::createStreamingSettings(obs_data_t *settings, si
         );
     }
 
+    QString server = obs_data_get_string(streamingSettings, "server");
+    QString adjustedServer = applyDefaultSrtListenTimeout(server);
+    if (adjustedServer != server) {
+        obs_log(LOG_INFO, "%s (%zu): Applied default SRT listen_timeout to listener URL", qUtf8Printable(name), index);
+        obs_data_set_string(streamingSettings, "server", qUtf8Printable(adjustedServer));
+    }
+
     return streamingSettings;
 }
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -28,6 +28,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <optional>
 
 #include <QString>
+#include <QStringList>
 #include <QWidget>
 #include <QVariant>
 
@@ -158,6 +159,45 @@ inline void loadHotkey(obs_hotkey_id id, const char *name)
 inline QString getIndexedPropNameFormat(size_t index, size_t base = 0)
 {
     return index == base ? QString("%1") : QString("%%1_%1").arg(index);
+}
+
+// Default SRT listener accept timeout in microseconds (matches the unit of the
+// SRT URL "listen_timeout" query parameter consumed by OBS's ffmpeg mpegts muxer).
+#define DEFAULT_SRT_LISTEN_TIMEOUT_US 5000000
+
+// An SRT listener URL without "listen_timeout" makes srt_accept() block forever
+// while no peer is connected. OBS's ffmpeg_mpegts_stop_internal() then deadlocks
+// the calling thread in pthread_join() until a peer connects, so a peerless stop
+// freezes OBS. Append a bounded default timeout so a stop can complete; an
+// explicit listen_timeout in the URL is left untouched.
+inline QString applyDefaultSrtListenTimeout(const QString &url)
+{
+    if (!url.startsWith("srt://", Qt::CaseInsensitive)) {
+        return url;
+    }
+
+    auto queryPos = url.indexOf('?');
+    if (queryPos < 0) {
+        return url;
+    }
+
+    const auto params = url.mid(queryPos + 1).split('&', Qt::SkipEmptyParts);
+    bool isListener = false;
+    bool hasListenTimeout = false;
+    for (const auto &param : params) {
+        const auto key = param.section('=', 0, 0);
+        if (key == "mode" && param.section('=', 1) == "listener") {
+            isListener = true;
+        } else if (key == "listen_timeout") {
+            hasListenTimeout = true;
+        }
+    }
+
+    if (!isListener || hasListenTimeout) {
+        return url;
+    }
+
+    return QString("%1&listen_timeout=%2").arg(url).arg(DEFAULT_SRT_LISTEN_TIMEOUT_US);
 }
 
 inline bool encoderAvailable(const char *encoder)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -165,10 +165,41 @@ inline QString getIndexedPropNameFormat(size_t index, size_t base = 0)
 // SRT URL "listen_timeout" query parameter consumed by OBS's ffmpeg mpegts muxer).
 #define DEFAULT_SRT_LISTEN_TIMEOUT_US 5000000
 
-// An SRT listener URL without "listen_timeout" makes OBS's libsrt block in
-// srt_accept() until a peer connects; a peerless stop then deadlocks the caller
-// in ffmpeg_mpegts_stop_internal()'s pthread_join(). Inject a bounded default so
-// a stop can complete; an explicit listen_timeout is left as-is.
+// True when OBS's libsrt derives a strictly positive listen_timeout from this raw
+// query value; only a positive value bounds the srt_accept() wait. Mirrors
+// av_find_info_tag (which decodes '+' to space) followed by strtoll prefix
+// parsing, which yields 0 for empty, non-numeric and leading-garbage values.
+inline bool isPositiveSrtTimeoutValue(const QString &value)
+{
+    auto decoded = QString(value).replace('+', ' ');
+
+    auto pos = 0;
+    while (pos < decoded.size() && QString(" \t\n\v\f\r").contains(decoded.at(pos))) {
+        pos++;
+    }
+    if (pos < decoded.size() && decoded.at(pos) == '-') {
+        return false;
+    }
+
+    for (; pos < decoded.size(); pos++) {
+        const auto digit = decoded.at(pos);
+        if (digit < '0' || digit > '9') {
+            break;
+        }
+        if (digit != '0') {
+            // Digits beyond this point can only increase the magnitude, and strtoll
+            // saturates at INT64_MAX instead of wrapping.
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// An SRT listener URL that yields no positive "listen_timeout" makes OBS's libsrt
+// block in srt_accept() until a peer connects; a peerless stop then deadlocks the
+// caller in ffmpeg_mpegts_stop_internal()'s pthread_join(). Inject or repair the
+// parameter so a stop can complete; an explicit positive value is left as-is.
 //
 // Matching is case-sensitive to mirror OBS's libsrt parsing (strncmp scheme,
 // av_find_info_tag keys); a case-insensitive match could treat a key OBS ignores
@@ -184,20 +215,34 @@ inline QString applyDefaultSrtListenTimeout(const QString &url)
         return url;
     }
 
-    const auto params = url.mid(queryPos + 1).split('&', Qt::SkipEmptyParts);
-    bool isListener = false;
-    bool hasListenTimeout = false;
-    for (const auto &param : params) {
-        const auto key = param.section('=', 0, 0);
-        if (key == "mode" && param.section('=', 1) == "listener") {
-            isListener = true;
-        } else if (key == "listen_timeout") {
-            hasListenTimeout = true;
+    // av_find_info_tag returns the first occurrence of a key, so only the first
+    // "mode" / "listen_timeout" in the query is the one OBS acts on.
+    auto params = url.mid(queryPos + 1).split('&');
+    auto modeIndex = -1;
+    auto timeoutIndex = -1;
+    for (auto i = 0; i < params.size(); i++) {
+        const auto key = params.at(i).section('=', 0, 0);
+        if (key == "mode" && modeIndex < 0) {
+            modeIndex = i;
+        } else if (key == "listen_timeout" && timeoutIndex < 0) {
+            timeoutIndex = i;
         }
     }
 
-    if (!isListener || hasListenTimeout) {
+    if (modeIndex < 0 || params.at(modeIndex).section('=', 1) != "listener") {
         return url;
+    }
+
+    const auto defaultParam = QString("listen_timeout=%1").arg(DEFAULT_SRT_LISTEN_TIMEOUT_US);
+
+    if (timeoutIndex >= 0) {
+        if (isPositiveSrtTimeoutValue(params.at(timeoutIndex).section('=', 1))) {
+            return url;
+        }
+
+        // Appending would be ignored because the existing occurrence comes first.
+        params[timeoutIndex] = defaultParam;
+        return url.left(queryPos + 1) + params.join('&');
     }
 
     // Trim trailing '&' so a user query ending in '&' does not yield "&&".
@@ -206,7 +251,7 @@ inline QString applyDefaultSrtListenTimeout(const QString &url)
         base.chop(1);
     }
 
-    return QString("%1&listen_timeout=%2").arg(base).arg(DEFAULT_SRT_LISTEN_TIMEOUT_US);
+    return QString("%1&%2").arg(base).arg(defaultParam);
 }
 
 inline bool encoderAvailable(const char *encoder)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -165,14 +165,17 @@ inline QString getIndexedPropNameFormat(size_t index, size_t base = 0)
 // SRT URL "listen_timeout" query parameter consumed by OBS's ffmpeg mpegts muxer).
 #define DEFAULT_SRT_LISTEN_TIMEOUT_US 5000000
 
-// An SRT listener URL without "listen_timeout" makes srt_accept() block forever
-// while no peer is connected. OBS's ffmpeg_mpegts_stop_internal() then deadlocks
-// the calling thread in pthread_join() until a peer connects, so a peerless stop
-// freezes OBS. Append a bounded default timeout so a stop can complete; an
-// explicit listen_timeout in the URL is left untouched.
+// An SRT listener URL without "listen_timeout" makes OBS's libsrt block in
+// srt_accept() until a peer connects; a peerless stop then deadlocks the caller
+// in ffmpeg_mpegts_stop_internal()'s pthread_join(). Inject a bounded default so
+// a stop can complete; an explicit listen_timeout is left as-is.
+//
+// Matching is case-sensitive to mirror OBS's libsrt parsing (strncmp scheme,
+// av_find_info_tag keys); a case-insensitive match could treat a key OBS ignores
+// as present and wrongly skip injection.
 inline QString applyDefaultSrtListenTimeout(const QString &url)
 {
-    if (!url.startsWith("srt://", Qt::CaseInsensitive)) {
+    if (!url.startsWith("srt://")) {
         return url;
     }
 
@@ -197,7 +200,13 @@ inline QString applyDefaultSrtListenTimeout(const QString &url)
         return url;
     }
 
-    return QString("%1&listen_timeout=%2").arg(url).arg(DEFAULT_SRT_LISTEN_TIMEOUT_US);
+    // Trim trailing '&' so a user query ending in '&' does not yield "&&".
+    QString base = url;
+    while (base.endsWith('&')) {
+        base.chop(1);
+    }
+
+    return QString("%1&listen_timeout=%2").arg(base).arg(DEFAULT_SRT_LISTEN_TIMEOUT_US);
 }
 
 inline bool encoderAvailable(const char *encoder)


### PR DESCRIPTION
## Summary

Fixes #147 (SRT listener stop hangs OBS, then crashes when a peer connects).

### Root causes

An SRT listener URL without a positive `listen_timeout` makes `srt_accept()` block forever while no
peer is connected. libobs never marks such an output active, so `obs_output_stop()` is a no-op and
the hang actually happens when the output is released: `ffmpeg_mpegts_destroy()` joins the still
blocked start thread, freezing the calling (UI) thread until a peer connects.

The crash follows from the same block. When a peer finally connects, the start thread resumes and
reaches `obs_output_begin_data_capture()`, binding the shared encoders to an output that is already
inside its destroy callback. `obs_output_destroy()` has passed its `active()` check by then, so it
never ends data capture and never calls `obs_encoder_stop()` — the only path that reaches
`audio_output_disconnect()`. The encoders stay registered as inputs on their `audio_t`, and
`obs_encoder_destroy()` tears down `pause.mutex` without disconnecting, so the next encoder release
is a use-after-free in the audio worker (`receive_audio` → `audio_pause_check` →
`pthread_mutex_unlock`, matching the reported crash log).

## Changes

- **`releaseInfrastructureIfIdle()`**: close the per-track `audio_t` (which joins its worker thread)
  *before* releasing the encoder. `audio_output_close()` joins the worker and frees every mix input,
  so an encoder that is still registered can no longer be called once the close returns, and its
  `pause.mutex` outlives the worker's final iteration.
- **`releaseInfrastructureIfIdle()`**: stop the private `video_t` before releasing the video
  encoder, mirroring the audio ordering. `obs_view_remove()` only flags the mix for removal on the
  graphics thread, so it cannot serve as that synchronization point; `video_output_stop()` joins the
  video worker and is idempotent with the `video_output_close()` that follows during mix teardown.
- **`applyDefaultSrtListenTimeout()`** (new helper in `utils.hpp`): for `srt://` URLs with
  `mode=listener` and no positive `listen_timeout`, apply a bounded default
  (`listen_timeout=5000000`, 5 s in microseconds). Values that OBS's `strtoll()` would resolve to
  zero or negative (empty, non-numeric, `0`, `-1`) are rewritten in place, because
  `av_find_info_tag()` returns the first occurrence of a key and an appended parameter would be
  ignored. Wired into `createStreamingSettings()` for all streaming slots.

A timed-out listener is restarted by the existing interval timer (~1 s), so the listener stays
effectively available while a peerless stop is now bounded to ~5 s instead of hanging indefinitely.

## Scope and rationale

These points came up in review and were deliberately left out of this PR.

### The bounded timeout is a mitigation, not a fix

`listen_timeout` is FFmpeg's accept deadline, not a shutdown guard, so expiry ends the connection
attempt and the socket is rebound on the next interval tick. That leaves a short recurring window in
which the listener is not accepting, and a stop can still block for up to the configured timeout.

The alternative — a cancellation-aware listener shutdown that interrupts the pending `srt_accept()`
— is not available. [obsproject/obs-studio#12250](https://github.com/obsproject/obs-studio/issues/12250)
reports the same inability to stop an SRT listener and was closed in June 2025: reworking the libobs
output pipeline for pull-style outputs was judged too extensive, and the maintainer noted that
listener mode might be disabled outright instead. The relevant code is unchanged on `master` as of
32.2.1 — `obs-ffmpeg-mpegts.c` and `obs-ffmpeg-srt.h` are byte-identical to 32.1.1, and neither
`obs_output_destroy()` nor `obs_encoder_destroy()` has gained a disconnect path.

Given that, a bounded timeout plus timer-driven restart is the only mitigation available from plugin
code.

### Explicitly configured positive timeouts are left alone

A large explicit value such as `listen_timeout=3600000000` is not overridden, so stopping a peerless
listener configured that way can still block for that long. This is intentional. The plugin passes
every other SRT query parameter (`latency`, `pbkeylen`, `maxbw`, `transtype`, …) through untouched,
and OBS does not clamp `listen_timeout` either; silently rewriting one key would be inconsistent and
would break the legitimate case of arming a listener for a long wait. The guarantee this PR makes is
narrower and explicit: **when no valid positive `listen_timeout` is configured, a bounded one is
applied.**

### Detaching encoders before releasing the output was rejected

Clearing the output's encoder slots while it is still libobs-inactive would make
`can_begin_data_capture()` fail, so a start thread that unblocks during the destroy-time join could
no longer bind the encoders. It is not safe: `obs_output_begin_data_capture()` sets `output->active`
as its last statement, after `pair_encoders()`, `hook_data_capture()` and `calculate_batch_size()`
have already read the slots and started the encoders. `obs_output_active()` is therefore not a
synchronization barrier, and detaching concurrently with a peer connecting can leave an encoder
connected to its `audio_t` with the output no longer referencing it — the very state this would try
to prevent.

`obs_output_force_stop()` is not a substitute either: it always runs
`obs_output_actual_stop(output, true, 0)`, which resets `stopping_event`, while the mpegts stop path
only signals it when `running && signal`. A second stop can therefore leave `obs_output_destroy()`
blocked in `os_event_wait(stopping_event)`.

### Two paths that the teardown ordering cannot reach are tracked separately

The ordering fixes protect every encoder whose media the plugin can close synchronously. Two paths
fall outside that and are tracked in #161 rather than bundled here.

- **Master track without "blank when not visible" + "mute audio when blank".** The encoder is bound
  to OBS's global `audio_t` (`obs_get_audio()`) instead of a plugin-owned one, and the global
  `audio_t` cannot be closed. Closing the gap means routing master tracks through
  `MasterAudioCapture` so every `audio_t` is plugin-owned, which changes the audio path for a
  default configuration.
- **GPU video encoders.** NVENC / QSV / AMF encoders are driven from libobs' GPU encode thread via
  the video mix's `gpu_encoders` array, which only `obs_encoder_stop()` detaches; `video_output_stop()`
  covers the raw-video worker but not that array.

Both would be closed by resolving an output's start (activation or terminal failure) before
releasing shared infrastructure, which is a lifecycle change beyond this PR's scope. The reported
crash is on the capture-owned audio path (`FilterAudioCapture`) and is covered here.

#161 also records the two teardown approaches that were implemented or evaluated here and rejected,
so they are not retried.

## Verification

- clang-format 17.0.6 applied.
- `cmake --build build_x64 --config RelWithDebInfo` builds `osi-branch-output.dll` cleanly (no
  warnings).
- No automated test suite in this repo; verified by build plus a source-level trace against
  obs-studio `master`. Manual on-device verification (enable SRT listener → disable with no sender →
  no hang; connect sender afterwards → no crash) still recommended on the maintainer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
