### PR TITLE
fix: Recover from stalled OBS reconnect via graceful restart (#146)

### DIFF
--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1387,11 +1387,24 @@ void BranchOutputFilter::onIntervalTimerTimeout()
             }
 
             for (size_t i = 0; i < MAX_SERVICES; i++) {
-                if (streamings[i].active && streamings[i].output && !obs_output_active(streamings[i].output) &&
-                    !obs_output_reconnecting(streamings[i].output)) {
+                if (!streamings[i].active || !streamings[i].output) {
+                    continue;
+                }
+                if (!obs_output_active(streamings[i].output) && !obs_output_reconnecting(streamings[i].output)) {
                     // Restart streaming
                     obs_log(LOG_INFO, "%s (%zu): Attempting reactivate the streaming output", qUtf8Printable(name), i);
                     reconnectStreamingOutput(i);
+                } else if (obs_output_reconnecting(streamings[i].output) && reconnectStallDetected(i)) {
+                    // OBS internal reconnect is stalled (TCP connect or RTMP handshake hung with
+                    // no progress). obs_output_stop() must not be called directly while reconnecting
+                    // (crashes OBS), so route recovery through the crash-safe graceful stop path.
+                    // The output is recreated by the start-evaluation logic on a later tick.
+                    // Limit to one slot per tick to avoid rapid state transitions.
+                    obs_log(
+                        LOG_WARNING, "%s (%zu): Reconnect stalled, forcing graceful restart", qUtf8Printable(name), i
+                    );
+                    stopSingleStreamingIndividual(i);
+                    return;
                 }
             }
 

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1422,8 +1422,9 @@ void BranchOutputFilter::onIntervalTimerTimeout()
                                 LOG_WARNING, "%s (%zu): Reconnect stalled, forcing graceful restart",
                                 qUtf8Printable(name), i
                             );
-                            // FIXME: obs_output_stop() pthread_joins the uninterruptible reconnect thread; a hung connect
-                            // blocks under pluginMutex + outputMutex. Root-cause fix (bounded/non-joining stop) needs a separate PR.
+                            // FIXME: obs_output_stop() joins the output's in-flight connect thread, so a hung
+                            // connect blocks this timer thread under pluginMutex + outputMutex. Root-cause fix
+                            // (bounded/non-joining stop) needs a separate PR.
                             stopSingleStreamingIndividual(i);
                             return;
                         }

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1422,8 +1422,9 @@ void BranchOutputFilter::onIntervalTimerTimeout()
                             );
                             // FIXME: obs_output_stop() pthread_joins the uninterruptible reconnect
                             // thread, so a hung connect blocks this timer thread under
-                            // pluginMutex + outputMutex. Root-cause fix (bounded/non-joining stop)
-                            // is out of plugin scope — track in a separate PR.
+                            // pluginMutex + outputMutex — stalling all threads that contend for
+                            // those mutexes, not just this timer. Root-cause fix (bounded/non-joining
+                            // stop) is out of plugin scope — track in a separate PR.
                             stopSingleStreamingIndividual(i);
                             return;
                         }

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1414,17 +1414,16 @@ void BranchOutputFilter::onIntervalTimerTimeout()
                             // OBS internal reconnect is stalled (TCP connect or RTMP handshake hung
                             // with no progress). obs_output_stop() must not be called directly while
                             // reconnecting (crashes OBS), so route recovery through the crash-safe
-                            // graceful stop path. Limit to one slot per tick to avoid rapid state
-                            // transitions.
+                            // graceful stop path. This only stops the slot; restart is performed by
+                            // a later tick's startEligibleStreamings() (INDIVIDUAL: L1176,
+                            // non-INDIVIDUAL: L1236). Limit to one slot per tick to avoid rapid
+                            // state transitions.
                             obs_log(
                                 LOG_WARNING, "%s (%zu): Reconnect stalled, forcing graceful restart",
                                 qUtf8Printable(name), i
                             );
-                            // FIXME: obs_output_stop() pthread_joins the uninterruptible reconnect
-                            // thread, so a hung connect blocks this timer thread under
-                            // pluginMutex + outputMutex — stalling all threads that contend for
-                            // those mutexes, not just this timer. Root-cause fix (bounded/non-joining
-                            // stop) is out of plugin scope — track in a separate PR.
+                            // FIXME: obs_output_stop() pthread_joins the uninterruptible reconnect thread; a hung connect
+                            // blocks under pluginMutex + outputMutex. Root-cause fix (bounded/non-joining stop) needs a separate PR.
                             stopSingleStreamingIndividual(i);
                             return;
                         }

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1422,9 +1422,14 @@ void BranchOutputFilter::onIntervalTimerTimeout()
                                 LOG_WARNING, "%s (%zu): Reconnect stalled, forcing graceful restart",
                                 qUtf8Printable(name), i
                             );
-                            // FIXME: obs_output_stop() joins the output's in-flight connect thread, so a hung
-                            // connect blocks this timer thread under pluginMutex + outputMutex. Root-cause fix
-                            // (bounded/non-joining stop) needs a separate PR.
+                            // FIXME: obs_output_stop() on a reconnecting output reaches the output
+                            // implementation's stop callback, which joins the in-flight connect
+                            // thread (rtmp_stream_stop() -> pthread_join(connect_thread)) with no
+                            // bound other than the OS connect / handshake timeout, blocking this
+                            // timer thread while pluginMutex and outputMutex are held. libobs' own
+                            // reconnect-thread join is not the blocker; reconnect_stop_event
+                            // releases it. Root-cause fix (bounded / non-joining stop) needs a
+                            // separate PR.
                             stopSingleStreamingIndividual(i);
                             return;
                         }

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -1386,25 +1386,48 @@ void BranchOutputFilter::onIntervalTimerTimeout()
                 restartRecordingOutput();
             }
 
-            for (size_t i = 0; i < MAX_SERVICES; i++) {
-                if (!streamings[i].active || !streamings[i].output) {
-                    continue;
-                }
-                if (!obs_output_active(streamings[i].output) && !obs_output_reconnecting(streamings[i].output)) {
-                    // Restart streaming
-                    obs_log(LOG_INFO, "%s (%zu): Attempting reactivate the streaming output", qUtf8Printable(name), i);
-                    reconnectStreamingOutput(i);
-                } else if (obs_output_reconnecting(streamings[i].output) && reconnectStallDetected(i)) {
-                    // OBS internal reconnect is stalled (TCP connect or RTMP handshake hung with
-                    // no progress). obs_output_stop() must not be called directly while reconnecting
-                    // (crashes OBS), so route recovery through the crash-safe graceful stop path.
-                    // The output is recreated by the start-evaluation logic on a later tick.
-                    // Limit to one slot per tick to avoid rapid state transitions.
-                    obs_log(
-                        LOG_WARNING, "%s (%zu): Reconnect stalled, forcing graceful restart", qUtf8Printable(name), i
-                    );
-                    stopSingleStreamingIndividual(i);
-                    return;
+            // Guard per-slot streamings[i].output access against concurrent nulling in
+            // stopStreamingOutput() / releaseInfrastructureIfIdle(). Lock order:
+            // pluginMutex -> outputMutex (matches stopOutputGracefully() and the
+            // Individual stop functions). Inner calls re-enter these recursive mutexes.
+            pthread_mutex_lock(&pluginMutex);
+            {
+                OBSMutexAutoUnlock pluginLocked(&pluginMutex);
+
+                pthread_mutex_lock(&outputMutex);
+                {
+                    OBSMutexAutoUnlock outputLocked(&outputMutex);
+
+                    for (size_t i = 0; i < MAX_SERVICES; i++) {
+                        if (!streamings[i].active || !streamings[i].output) {
+                            continue;
+                        }
+                        if (!obs_output_active(streamings[i].output) &&
+                            !obs_output_reconnecting(streamings[i].output)) {
+                            // Restart streaming
+                            obs_log(
+                                LOG_INFO, "%s (%zu): Attempting reactivate the streaming output", qUtf8Printable(name),
+                                i
+                            );
+                            reconnectStreamingOutput(i);
+                        } else if (obs_output_reconnecting(streamings[i].output) && reconnectStallDetected(i)) {
+                            // OBS internal reconnect is stalled (TCP connect or RTMP handshake hung
+                            // with no progress). obs_output_stop() must not be called directly while
+                            // reconnecting (crashes OBS), so route recovery through the crash-safe
+                            // graceful stop path. Limit to one slot per tick to avoid rapid state
+                            // transitions.
+                            obs_log(
+                                LOG_WARNING, "%s (%zu): Reconnect stalled, forcing graceful restart",
+                                qUtf8Printable(name), i
+                            );
+                            // FIXME: obs_output_stop() pthread_joins the uninterruptible reconnect
+                            // thread, so a hung connect blocks this timer thread under
+                            // pluginMutex + outputMutex. Root-cause fix (bounded/non-joining stop)
+                            // is out of plugin scope — track in a separate PR.
+                            stopSingleStreamingIndividual(i);
+                            return;
+                        }
+                    }
                 }
             }
 

--- a/src/plugin-main.hpp
+++ b/src/plugin-main.hpp
@@ -82,6 +82,7 @@ class BranchOutputFilter : public QObject {
         OBSSignal outputStartingSignal;
         OBSSignal outputActivateSignal;
         OBSSignal outputReconnectSignal;
+        OBSSignal outputReconnectSuccessSignal;
         OBSSignal outputStopSignal;
     };
 

--- a/src/plugin-main.hpp
+++ b/src/plugin-main.hpp
@@ -216,6 +216,7 @@ class BranchOutputFilter : public QObject {
     void stopStreamingOutput(size_t index = 0);
     void reconnectStreamingOutput(size_t index = 0);
     bool reconnectAttemptingTimedOut(size_t index = 0);
+    bool reconnectStallDetected(size_t index = 0);
     bool someStreamingsStarting();
     int countEnabledStreamings(obs_data_t *settings);
     int countAliveStreamings();

--- a/src/plugin-streaming.cpp
+++ b/src/plugin-streaming.cpp
@@ -32,8 +32,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #define RECONNECT_ATTEMPTING_TIMEOUT_NS 2000000000ULL
 // RECONNECT_STALL_TIMEOUT_NS must exceed RECONNECT_ATTEMPTING_TIMEOUT_NS:
 // stall detection guarantees the graceful-stop timeout has already elapsed.
-// Threshold for detecting a stalled OBS reconnect (TCP connect / RTMP handshake hung
-// with no progress). False positives are possible for slow-but-valid reconnects with long backoff intervals.
 #define RECONNECT_STALL_TIMEOUT_NS 30000000000ULL
 
 obs_data_t *BranchOutputFilter::createStreamingSettings(obs_data_t *settings, size_t index)

--- a/src/plugin-streaming.cpp
+++ b/src/plugin-streaming.cpp
@@ -30,11 +30,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #define OUTPUT_MAX_RETRIES 7
 #define OUTPUT_RETRY_DELAY_SECS 1
 #define RECONNECT_ATTEMPTING_TIMEOUT_NS 2000000000ULL
+// RECONNECT_STALL_TIMEOUT_NS must exceed RECONNECT_ATTEMPTING_TIMEOUT_NS:
+// stall detection guarantees the graceful-stop timeout has already elapsed.
 // Threshold for detecting a stalled OBS reconnect (TCP connect / RTMP handshake hung
-// with no progress). This is an intentional aggressive recovery bound, not a precise
-// classification threshold; slow-but-valid reconnects that happen to exceed 30 s
-// (e.g., late attempts with exponential backoff plus a long TCP connect) may also
-// trigger recovery.
+// with no progress). False positives are possible for slow-but-valid reconnects with long backoff intervals.
 #define RECONNECT_STALL_TIMEOUT_NS 30000000000ULL
 
 obs_data_t *BranchOutputFilter::createStreamingSettings(obs_data_t *settings, size_t index)

--- a/src/plugin-streaming.cpp
+++ b/src/plugin-streaming.cpp
@@ -549,7 +549,10 @@ bool BranchOutputFilter::stopSingleStreamingOutputGracefully(size_t index)
 
     if (streamings[index].output && streamings[index].active) {
         if (streamings[index].stopping) {
-            if (reconnectAttemptingTimedOut(index)) {
+            // A reconnect that succeeds clears reconnectAttemptingAt, so the timeout gate alone
+            // would never open once "stopping" is latched. Leaving the reconnecting state is
+            // itself sufficient grounds to stop.
+            if (!obs_output_reconnecting(streamings[index].output) || reconnectAttemptingTimedOut(index)) {
                 stopStreamingOutput(index);
             } else {
                 return false;

--- a/src/plugin-streaming.cpp
+++ b/src/plugin-streaming.cpp
@@ -30,6 +30,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #define OUTPUT_MAX_RETRIES 7
 #define OUTPUT_RETRY_DELAY_SECS 1
 #define RECONNECT_ATTEMPTING_TIMEOUT_NS 2000000000ULL
+// Threshold for detecting a stalled OBS reconnect (TCP connect / RTMP handshake hung
+// with no progress). Must be well above OUTPUT_MAX_RETRIES * OUTPUT_RETRY_DELAY_SECS
+// so a normal retry sequence is never misclassified as a stall.
+#define RECONNECT_STALL_TIMEOUT_NS 30000000000ULL
 
 obs_data_t *BranchOutputFilter::createStreamingSettings(obs_data_t *settings, size_t index)
 {
@@ -254,6 +258,12 @@ bool BranchOutputFilter::reconnectAttemptingTimedOut(size_t index)
 {
     auto attemptingAt = streamings[index].reconnectAttemptingAt.load();
     return attemptingAt && os_gettime_ns() - attemptingAt > RECONNECT_ATTEMPTING_TIMEOUT_NS;
+}
+
+bool BranchOutputFilter::reconnectStallDetected(size_t index)
+{
+    auto attemptingAt = streamings[index].reconnectAttemptingAt.load();
+    return attemptingAt && os_gettime_ns() - attemptingAt > RECONNECT_STALL_TIMEOUT_NS;
 }
 
 void BranchOutputFilter::setStreamingUserEnabled(size_t index, bool enabled)

--- a/src/plugin-streaming.cpp
+++ b/src/plugin-streaming.cpp
@@ -31,8 +31,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #define OUTPUT_RETRY_DELAY_SECS 1
 #define RECONNECT_ATTEMPTING_TIMEOUT_NS 2000000000ULL
 // Threshold for detecting a stalled OBS reconnect (TCP connect / RTMP handshake hung
-// with no progress). Must be well above OUTPUT_MAX_RETRIES * OUTPUT_RETRY_DELAY_SECS
-// so a normal retry sequence is never misclassified as a stall.
+// with no progress). This is an intentional aggressive recovery bound, not a precise
+// classification threshold; slow-but-valid reconnects that happen to exceed 30 s
+// (e.g., late attempts with exponential backoff plus a long TCP connect) may also
+// trigger recovery.
 #define RECONNECT_STALL_TIMEOUT_NS 30000000000ULL
 
 obs_data_t *BranchOutputFilter::createStreamingSettings(obs_data_t *settings, size_t index)
@@ -170,6 +172,9 @@ void BranchOutputFilter::startStreamingOutput(size_t index)
         [](void *_data, calldata_t *) {
             auto context = static_cast<BranchOutputStreamingContext *>(_data);
             context->outputStarting = false;
+            // Clear any stale reconnect timestamp so a later reconnect episode is not
+            // misjudged as stalled by reconnectStallDetected() / reconnectAttemptingTimedOut().
+            context->reconnectAttemptingAt = 0;
             obs_log(LOG_DEBUG, "%s: Streaming output has activated", obs_output_get_name(context->output));
         },
         &streamings[index]
@@ -182,6 +187,17 @@ void BranchOutputFilter::startStreamingOutput(size_t index)
             auto context = static_cast<BranchOutputStreamingContext *>(_data);
             context->reconnectAttemptingAt = os_gettime_ns();
             obs_log(LOG_DEBUG, "%s: Streaming output is reconnecting", obs_output_get_name(context->output));
+        },
+        &streamings[index]
+    );
+
+    // Track reconnect_success signal (delayed-capture reconnect path emits this without "activate")
+    streamings[index].outputReconnectSuccessSignal.Connect(
+        obs_output_get_signal_handler(streamings[index].output), "reconnect_success",
+        [](void *_data, calldata_t *) {
+            auto context = static_cast<BranchOutputStreamingContext *>(_data);
+            context->reconnectAttemptingAt = 0;
+            obs_log(LOG_DEBUG, "%s: Streaming output reconnected", obs_output_get_name(context->output));
         },
         &streamings[index]
     );
@@ -228,6 +244,7 @@ void BranchOutputFilter::stopStreamingOutput(size_t index)
     streamings[index].outputStartingSignal.Disconnect();
     streamings[index].outputActivateSignal.Disconnect();
     streamings[index].outputReconnectSignal.Disconnect();
+    streamings[index].outputReconnectSuccessSignal.Disconnect();
     streamings[index].outputStopSignal.Disconnect();
 
     streamings[index].output = nullptr;


### PR DESCRIPTION
## Summary

Fixes #146 — Branch Output streams to YouTube (and other RTMP targets) can get
permanently stuck in the "Reconnecting" state. OBS's internal reconnect thread can
stall in a hung TCP connect / RTMP handshake, so `obs_output_reconnecting()` stays
true indefinitely and the existing reactivation path (which only fires when the
output is neither active nor reconnecting) never triggers.

This PR adds stall detection and recovers through the existing crash-safe graceful
stop path, with no new threading model.

## Changes

- **Stall detection** (`reconnectStallDetected()`): a reconnecting output whose
  reconnect timestamp is older than `RECONNECT_STALL_TIMEOUT_NS` (30 s) is treated
  as stalled.
- **Recovery via the existing crash-safe path**: a stalled slot is routed through
  `stopSingleStreamingIndividual()`, which recreates the output automatically.
  `obs_output_stop()` must not be called directly while reconnecting (crashes OBS),
  so the graceful stop path is reused. Limited to one slot per tick to avoid rapid
  state transitions.
- **Thread-safety hardening**: the per-slot reactivation loop is now guarded by
  `pluginMutex` → `outputMutex` (matching the lock order of `stopOutputGracefully()`
  and the Individual stop functions) against concurrent output nulling in
  `stopStreamingOutput()` / `releaseInfrastructureIfIdle()`.
- **False-positive hardening**: the reconnect timestamp is cleared on `activate` and
  on the newly tracked `reconnect_success` signal (the delayed-capture reconnect path
  emits `reconnect_success` without `activate`), so a healthy reconnect is not
  misjudged as stalled.
- **Graceful stop no longer latches when a reconnect succeeds**: once
  `stopSingleStreamingOutputGracefully()` has set `stopping`, it now also stops as soon
  as the output leaves the reconnecting state. Clearing the reconnect timestamp (above)
  makes `reconnectAttemptingTimedOut()` report "not yet timed out", so without this the
  `stopping` branch would never open again and a stop requested during a reconnect that
  subsequently succeeds would be ignored for the rest of the output's lifetime.
- **Invariant documented**: `RECONNECT_STALL_TIMEOUT_NS > RECONNECT_ATTEMPTING_TIMEOUT_NS`
  is now noted so a future change to either constant does not silently break the
  graceful-stop hand-off.

## Note on the 30 s threshold

Branch Output overrides OBS reconnect settings to
`obs_output_set_reconnect_settings(output, OUTPUT_MAX_RETRIES=7, OUTPUT_RETRY_DELAY_SECS=1)`.
With this bounded `(7, 1)` config the per-retry backoff gaps stay ~11–13 s (always
below the 30 s bound) and a normal reconnect episode caps at ~32 s / 7 retries before
the output goes inactive and is restarted by the existing path. Stall detection
therefore only trips on a genuinely hung single attempt that emits no further
`reconnect` signal and never goes inactive — the intended target.

## Known limitation (deferred, tracked by `FIXME:` for a separate PR)

Recovery calls `obs_output_stop()` on an output that is by definition stuck in a hung
connect, and that call blocks for as long as the hang lasts. This ships as a known
limitation.

Mechanism, traced through the bundled OBS 30.1.2 sources:

- `obs_output_stop()` on a reconnecting output takes the `obs_output_force_stop()` →
  `obs_output_actual_stop(force = true)` path, which invokes the output
  implementation's stop callback.
- For RTMP that callback is `rtmp_stream_stop()`, which runs
  `pthread_join(stream->connect_thread)` while a connect is in flight. This is the
  blocking join, and it is bounded only by the OS connect / handshake timeout — neither
  the plugin nor libobs exposes a timeout for it.
- The join therefore stalls the plugin's interval timer thread while `pluginMutex` and
  `outputMutex` are held.
- libobs' own `pthread_join(output->reconnect_thread)` in `obs_output_actual_stop()` is
  **not** the blocker: that function signals `reconnect_stop_event` beforehand, which
  releases the reconnect thread's `os_event_timedwait()`.

The root-cause fix is a bounded or non-joining stop for an output whose connect attempt
is already classified as hung, which is out of scope here.

## Verification

- Builds clean (Windows x64, RelWithDebInfo); clang-format / cmake-format clean.
- No automated tests in this repository; manual verification on a long-running RTMP
  stream that exercises a stalled reconnect is required.
- Manual verification also required for stop requests (filter disable, eye-icon hide,
  interlock stop, OBS shutdown) issued while a reconnect is in flight that then succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
