### PR TITLE
ci: Fix format check jobs failing during Homebrew dependency install

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -29,6 +29,8 @@ runs:
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
         echo "/home/linuxbrew/.linuxbrew/opt/clang-format@17/bin" >> $GITHUB_PATH
+        # Runner images ship an outdated Homebrew with auto-update off; current formulae fail without this.
+        brew update --quiet
         brew install --quiet zsh
         echo ::endgroup::
 

--- a/.github/actions/run-cmake-format/action.yaml
+++ b/.github/actions/run-cmake-format/action.yaml
@@ -28,6 +28,8 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+        # Runner images ship an outdated Homebrew with auto-update off; current formulae fail without this.
+        brew update --quiet
         brew install --quiet zsh
         echo ::endgroup::
 


### PR DESCRIPTION
## Summary

Both format check jobs (`clang-format`, `cmake-format`) fail on GitHub-hosted runners before any
formatter runs. The failure is in the Homebrew dependency install, not in the checked source.

## Root cause

The Homebrew preinstalled on the runner images is older than the formula definitions currently
served by the Homebrew API. Recent formulae declare post-install steps of kinds the runner's
Homebrew does not know, so `brew install` aborts:

```
==> Pouring glibc--2.39_1.x86_64_linux.bottle.tar.gz
##[error]unknown install step: remove
  .../Homebrew/install_steps.rb:570:in 'Homebrew::InstallSteps::Runner#run_install_step'
```

```
==> Pouring ca-certificates--2026-07-16.all.bottle.2.tar.gz
##[error]unknown install step: run
  .../Homebrew/install_steps.rb:570:in 'Homebrew::InstallSteps::Runner#run_install_step'
```

Runner images disable Homebrew auto-update, so `brew` never picks up the code that understands the
newer step kinds. Homebrew's own error output states the remedy: "Do not report this issue until
you've run `brew update` and tried again."

The two jobs fail on different formulae because of the runner image difference. On `ubuntu-22.04`
the `cmake-format` job pulls `glibc` as a `zsh` dependency and fails during `Install Dependencies`,
leaving `Run cmake-format` skipped. On `ubuntu-24.04` the `clang-format` job gets past `zsh` and
fails later, on `ca-certificates` as a `clang-format@17` dependency.

## Changes

- Run `brew update --quiet` before `brew install` in the `Install Dependencies` step of
  `run-clang-format` and `run-cmake-format`.

The `clang-format` action installs `obsproject/tools/clang-format@17` in a later step, on the same
runner. Updating Homebrew once in `Install Dependencies` covers that install as well.

## Verification

- `action.yaml` in both actions parses as valid YAML.
- The `cmake-format` job exercises the fix directly: its failure point, `brew install zsh` in
  `Install Dependencies`, runs unconditionally.
- The `clang-format` job exercises `brew install zsh` only. Its `brew install clang-format@17` is
  guarded by a changed-file check for C/C++ extensions, so a branch that touches no C/C++ sources
  skips it. That path is exercised by the next pull request that changes C/C++ sources.

Pull requests opened before this change is merged continue to fail, because `pull_request` runs read
the composite actions from the pull request head. They need `dev` merged in to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
