### PR TITLE
fix: Reload Status Dock hotkeys on profile changes

### DIFF
--- a/src/UI/output-status-dock.cpp
+++ b/src/UI/output-status-dock.cpp
@@ -239,13 +239,19 @@ BranchOutputStatusDock::~BranchOutputStatusDock()
 
 void BranchOutputStatusDock::loadHotkeys()
 {
-    loadHotkey(enableAllHotkey, "EnableAllBranchOutputsHotkey");
-    loadHotkey(disableAllHotkey, "DisableAllBranchOutputsHotkey");
-    loadHotkey(splitRecordingAllHotkey, "SplitRecordingAllBranchOutputsHotkey");
-    loadHotkey(pauseRecordingAllHotkey, "PauseRecordingAllBranchOutputsHotkey");
-    loadHotkey(unpauseRecordingAllHotkey, "UnpauseRecordingAllBranchOutputsHotkey");
-    loadHotkey(addChapterToRecordingAllHotkey, "AddChapterToRecordingAllBranchOutputsHotkey");
-    loadHotkey(saveReplayBufferAllHotkey, "SaveReplayBufferAllBranchOutputsHotkey");
+    obs_hotkey_update_atomic(
+        [](void *data) {
+            auto *dock = static_cast<BranchOutputStatusDock *>(data);
+            loadHotkey(dock->enableAllHotkey, "EnableAllBranchOutputsHotkey");
+            loadHotkey(dock->disableAllHotkey, "DisableAllBranchOutputsHotkey");
+            loadHotkey(dock->splitRecordingAllHotkey, "SplitRecordingAllBranchOutputsHotkey");
+            loadHotkey(dock->pauseRecordingAllHotkey, "PauseRecordingAllBranchOutputsHotkey");
+            loadHotkey(dock->unpauseRecordingAllHotkey, "UnpauseRecordingAllBranchOutputsHotkey");
+            loadHotkey(dock->addChapterToRecordingAllHotkey, "AddChapterToRecordingAllBranchOutputsHotkey");
+            loadHotkey(dock->saveReplayBufferAllHotkey, "SaveReplayBufferAllBranchOutputsHotkey");
+        },
+        this
+    );
 }
 
 void BranchOutputStatusDock::loadSettings()
@@ -346,12 +352,13 @@ void BranchOutputStatusDock::onOBSFrontendEvent(enum obs_frontend_event event, v
         dock->saveSettings();
         break;
     case OBS_FRONTEND_EVENT_PROFILE_CHANGED:
+        dock->loadHotkeys();
+
         // Defer to ensure Qt event loop has finished processing the profile change
         QMetaObject::invokeMethod(
             dock,
             [dock]() {
                 dock->loadSettings();
-                dock->loadHotkeys();
                 dock->sort();
             },
             Qt::QueuedConnection

--- a/src/UI/output-status-dock.cpp
+++ b/src/UI/output-status-dock.cpp
@@ -204,13 +204,7 @@ BranchOutputStatusDock::BranchOutputStatusDock(QWidget *parent)
     );
 
     loadSettings();
-    loadHotkey(enableAllHotkey, "EnableAllBranchOutputsHotkey");
-    loadHotkey(disableAllHotkey, "DisableAllBranchOutputsHotkey");
-    loadHotkey(splitRecordingAllHotkey, "SplitRecordingAllBranchOutputsHotkey");
-    loadHotkey(pauseRecordingAllHotkey, "PauseRecordingAllBranchOutputsHotkey");
-    loadHotkey(unpauseRecordingAllHotkey, "UnpauseRecordingAllBranchOutputsHotkey");
-    loadHotkey(addChapterToRecordingAllHotkey, "AddChapterToRecordingAllBranchOutputsHotkey");
-    loadHotkey(saveReplayBufferAllHotkey, "SaveReplayBufferAllBranchOutputsHotkey");
+    loadHotkeys();
 
     sort();
 
@@ -241,6 +235,17 @@ BranchOutputStatusDock::~BranchOutputStatusDock()
     obs_hotkey_unregister(saveReplayBufferAllHotkey);
 
     obs_log(LOG_DEBUG, "BranchOutputStatusDock destroyed");
+}
+
+void BranchOutputStatusDock::loadHotkeys()
+{
+    loadHotkey(enableAllHotkey, "EnableAllBranchOutputsHotkey");
+    loadHotkey(disableAllHotkey, "DisableAllBranchOutputsHotkey");
+    loadHotkey(splitRecordingAllHotkey, "SplitRecordingAllBranchOutputsHotkey");
+    loadHotkey(pauseRecordingAllHotkey, "PauseRecordingAllBranchOutputsHotkey");
+    loadHotkey(unpauseRecordingAllHotkey, "UnpauseRecordingAllBranchOutputsHotkey");
+    loadHotkey(addChapterToRecordingAllHotkey, "AddChapterToRecordingAllBranchOutputsHotkey");
+    loadHotkey(saveReplayBufferAllHotkey, "SaveReplayBufferAllBranchOutputsHotkey");
 }
 
 void BranchOutputStatusDock::loadSettings()
@@ -346,6 +351,7 @@ void BranchOutputStatusDock::onOBSFrontendEvent(enum obs_frontend_event event, v
             dock,
             [dock]() {
                 dock->loadSettings();
+                dock->loadHotkeys();
                 dock->sort();
             },
             Qt::QueuedConnection

--- a/src/UI/output-status-dock.cpp
+++ b/src/UI/output-status-dock.cpp
@@ -240,8 +240,8 @@ BranchOutputStatusDock::~BranchOutputStatusDock()
 void BranchOutputStatusDock::loadHotkeys()
 {
     obs_hotkey_update_atomic(
-        [](void *data) {
-            auto *dock = static_cast<BranchOutputStatusDock *>(data);
+        [](void *context) {
+            auto *dock = static_cast<BranchOutputStatusDock *>(context);
             loadHotkey(dock->enableAllHotkey, "EnableAllBranchOutputsHotkey");
             loadHotkey(dock->disableAllHotkey, "DisableAllBranchOutputsHotkey");
             loadHotkey(dock->splitRecordingAllHotkey, "SplitRecordingAllBranchOutputsHotkey");

--- a/src/UI/output-status-dock.hpp
+++ b/src/UI/output-status-dock.hpp
@@ -260,6 +260,7 @@ class BranchOutputStatusDock : public QFrame {
     void applySaveReplayBufferAllButtonEnabled();
     void saveSettings();
     void loadSettings();
+    void loadHotkeys();
     void applySettings(obs_data_t *settings);
 
     static void onOBSFrontendEvent(enum obs_frontend_event event, void *param);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -150,10 +150,16 @@ inline obs_data_t *loadHotkeyData(const char *name)
 inline void loadHotkey(obs_hotkey_id id, const char *name)
 {
     OBSDataAutoRelease data = loadHotkeyData(name);
+    OBSDataArrayAutoRelease array;
     if (data) {
-        OBSDataArrayAutoRelease array = obs_data_get_array(data, "bindings");
-        obs_hotkey_load(id, array);
+        array = obs_data_get_array(data, "bindings");
     }
+
+    if (!array) {
+        array = obs_data_array_create();
+    }
+
+    obs_hotkey_load(id, array);
 }
 
 inline QString getIndexedPropNameFormat(size_t index, size_t base = 0)

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -155,8 +155,9 @@ inline void loadHotkey(obs_hotkey_id id, const char *name)
         array = obs_data_get_array(data, "bindings");
     }
 
-    if (!array) {
-        array = obs_data_array_create();
+    if (!array || obs_data_array_count(array) == 0) {
+        obs_hotkey_load_bindings(id, nullptr, 0);
+        return;
     }
 
     obs_hotkey_load(id, array);


### PR DESCRIPTION
## Summary

- Reload all seven Status Dock frontend hotkey bindings when the active OBS profile changes.
- Clear missing or empty bindings instead of retaining stale bindings from the previous profile.
- Apply the binding reload as one atomic hotkey update to avoid exposing a partially updated set.
- Leave the per-filter source hotkey registration behavior tracked by #159 unchanged.

## Verification

- clang-format verification passed with no changes required.
- RelWithDebInfo build passed.
- Two adversarial CReview rounds completed; all three round-one findings were fixed and verified, and round two found no further issues.
- Automated tests are not declared for this repository.
- Manual OBS profile-switch testing was not performed in this environment.

Closes #163